### PR TITLE
Nflog conntrack

### DIFF
--- a/ctrmd.go
+++ b/ctrmd.go
@@ -15,7 +15,10 @@ import (
 var nflogGroup = flag.Int("g", 666, "NFLOG group to listen on")
 
 func main() {
-	logger, _ := syslog.New(syslog.LOG_DAEMON|syslog.LOG_INFO, "ctrmd")
+	logger, err := syslog.New(syslog.LOG_DAEMON|syslog.LOG_INFO, "ctrmd")
+	if err != nil {
+		log.Fatal("Could not create logger: ", err)
+	}
 	flag.Parse()
 
 	logger.Info("Opening conntrack socket")

--- a/ctrmd.go
+++ b/ctrmd.go
@@ -10,9 +10,12 @@ import (
 
 	conntrack "github.com/florianl/go-conntrack"
 	nflog "github.com/florianl/go-nflog"
+	ctprint "github.com/x-way/iptables-tracer/pkg/ctprint"
+	format "github.com/x-way/iptables-tracer/pkg/format"
 )
 
 var nflogGroup = flag.Int("g", 666, "NFLOG group to listen on")
+var debug = flag.Bool("d", false, "debug output")
 
 func main() {
 	logger, err := syslog.New(syslog.LOG_DAEMON|syslog.LOG_INFO, "ctrmd")
@@ -34,9 +37,13 @@ func main() {
 	config := nflog.Config{
 		Group:       uint16(*nflogGroup),
 		Copymode:    nflog.NfUlnlCopyPacket,
+		Flags:       nflog.NfUlnlCfgFConntrack,
 		ReadTimeout: 30 * time.Second,
 	}
 	logger.Info(fmt.Sprintf("Opening NFLOG socket for group %d", *nflogGroup))
+	if *debug {
+		fmt.Printf("Opening NFLOG socket for group %d\n", *nflogGroup)
+	}
 	nfl, err := nflog.Open(&config)
 	if err != nil {
 		log.Fatal(logger.Err(fmt.Sprintf("Could not open nflog socket: %v\n", err)))
@@ -44,12 +51,84 @@ func main() {
 	defer nfl.Close()
 
 	fn := func(m nflog.Msg) int {
-		if ctFamily, attrs, err := extractCtAttrs(m[nflog.AttrPayload].([]byte)); err != nil {
-			logger.Warning(fmt.Sprintf("Could not extract CT attrs from packet: %v\n", err))
+		var ctFamily conntrack.CtFamily
+		var attrs []conntrack.ConnAttr
+		var err error
+		var ct interface{}
+		var payload interface{}
+		var ctBytes []byte
+		var payloadBytes []byte
+		var ok bool
+		var fwMark uint32
+		var iif string
+		var oif string
+		if ct, ok = m[nflog.AttrCt]; ok {
+			ctBytes = ct.([]byte)
+			if ctFamily, attrs, err = extractCtAttrsFromCt(ctBytes); err != nil {
+				logger.Warning(fmt.Sprintf("Could not extract CT attrs from CT info: %v\n", err))
+				if *debug {
+					fmt.Printf("Could not extract CT attrs from CT info: %v\n", err)
+				}
+				return 0
+			}
 		} else {
-			//fmt.Printf("extracted: err: %v family: %v attrs: %v\n", err, ctFamily, attrs)
+			if *debug {
+				fmt.Println("No NFLOG CT info found, decoding information from payload")
+			}
+		}
+		if payload, ok = m[nflog.AttrPayload]; ok {
+			payloadBytes = payload.([]byte)
+			if len(attrs) == 0 {
+				if ctFamily, attrs, err = extractCtAttrsFromPayload(payloadBytes); err != nil {
+					logger.Warning(fmt.Sprintf("Could not extract CT attrs from packet payload: %v\n", err))
+					if *debug {
+						fmt.Printf("Could not extract CT attrs from CT info: %v\n", err)
+					}
+					return 0
+				}
+			}
+		} else {
+			logger.Warning(fmt.Sprintf("No NFLOG payload found, ignoring packet\n"))
+			if *debug {
+				fmt.Println("No NFLOG payload found, ignoring packet")
+			}
+			return 0
+		}
+
+		var ctInfo = ^uint32(0)
+		if mark, found := m[nflog.AttrMark]; found {
+			fwMark = mark.(uint32)
+		}
+		if iifIx, found := m[nflog.AttrIfindexIndev]; found {
+			iif = format.GetIfaceName(iifIx.(uint32))
+		}
+		if oifIx, found := m[nflog.AttrIfindexOutdev]; found {
+			oif = format.GetIfaceName(oifIx.(uint32))
+		}
+		if ct, found := m[nflog.AttrCt]; found {
+			ctBytes = ct.([]byte)
+		}
+		if cti, found := m[nflog.AttrCtInfo]; found {
+			ctInfo = cti.(uint32)
+		}
+		if len(attrs) > 0 {
+			logger.Info(fmt.Sprintf("Deleting CT entry: family: %v attrs: %v\n", ctFamily, attrs))
+			logger.Info(fmt.Sprintf(" Packet: %s\n", formatPkt(false, time.Now(), fwMark, iif, oif, payloadBytes, ctBytes, ctInfo)))
+			if *debug {
+				fmt.Printf("Deleting CT entry: family: %v attrs: %v\n", ctFamily, attrs)
+				fmt.Printf(" Packet: %s\n", formatPkt(false, time.Now(), fwMark, iif, oif, payloadBytes, ctBytes, ctInfo))
+				ctprint.Print(ctBytes)
+			}
 			if err = nfct.Delete(conntrack.Ct, ctFamily, attrs); err != nil {
 				logger.Warning(fmt.Sprintf("conntrack Delete failed: %v\n", err))
+				if *debug {
+					fmt.Printf("conntrack Delete failed: %v\n", err)
+				}
+			}
+		} else {
+			logger.Warning(fmt.Sprintf("List of extracted CT attributes is empty, ignoring packet\n"))
+			if *debug {
+				fmt.Println("List of extracted CT attributes is empty, ignoring packet")
 			}
 		}
 
@@ -62,4 +141,13 @@ func main() {
 
 	<-ctx.Done()
 	logger.Info("Terminating")
+}
+
+func formatPkt(ip6tables bool, ts time.Time, fwMark uint32, iif, oif string, payload []byte, ct []byte, ctInfo uint32) string {
+	var output string
+	packetStr := format.Packet(payload, ip6tables)
+	ctStr := fmt.Sprintf(" %s 0x%08x", ctprint.InfoString(ctInfo), ctprint.GetCtMark(ct))
+	fmtStr := "%s 0x%08x%s %s  [In:%s Out:%s]"
+	output = fmt.Sprintf(fmtStr, ts.Format("15:04:05.000000"), fwMark, ctStr, packetStr, iif, oif)
+	return output
 }

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,9 @@ module github.com/x-way/ctrmd
 go 1.12
 
 require (
-	github.com/florianl/go-conntrack v0.0.0-20190424094210-e011089a06c0
+	github.com/florianl/go-conntrack v0.0.0-20190429101121-fb09150ed07b
 	github.com/florianl/go-nflog v0.0.0-20190401084518-8393abb58fd4
 	github.com/google/gopacket v1.1.16
+	github.com/x-way/iptables-tracer v0.0.0-20190502200825-d3aba5b1e83d
+	golang.org/x/sys v0.0.0-20190415081028-16da32be82c5
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/florianl/go-conntrack v0.0.0-20190424094210-e011089a06c0 h1:pWIHYSkJsj7kUO94EjQoSA+MPlnWThhTHQ1k2EH4uJA=
 github.com/florianl/go-conntrack v0.0.0-20190424094210-e011089a06c0/go.mod h1:bVjd6LQuEVqwX8Mw3sMv22v569+H/3TQWW6itTFrBh8=
+github.com/florianl/go-conntrack v0.0.0-20190429101121-fb09150ed07b h1:70szY4XIV3Txth4VOkjK5dJP8aDkqFk0DVKXdhZeAKU=
+github.com/florianl/go-conntrack v0.0.0-20190429101121-fb09150ed07b/go.mod h1:bVjd6LQuEVqwX8Mw3sMv22v569+H/3TQWW6itTFrBh8=
 github.com/florianl/go-nflog v0.0.0-20190401084518-8393abb58fd4 h1:5/JwrpdIDlN02WLI2tXoxQC89WNUuIKtrBiXjQLSkN8=
 github.com/florianl/go-nflog v0.0.0-20190401084518-8393abb58fd4/go.mod h1:F0bpPphpbGBVmycNnkDFlHFpNY420laFpP0j1VL271I=
 github.com/google/go-cmp v0.2.0 h1:+dTQ8DZQJz0Mb/HjFlkptS1FeQ4cWSnN941F8aEG4SQ=
@@ -9,6 +11,18 @@ github.com/google/gopacket v1.1.16/go.mod h1:UCLx9mCmAwsVbn6qQl1WIEt2SO7Nd2fD0th
 github.com/mdlayher/netlink v0.0.0-20190313131330-258ea9dff42c/go.mod h1:eQB3mZE4aiYnlUsyGGCOpPETfdQq4Jhsgf1fk3cwQaA=
 github.com/mdlayher/netlink v0.0.0-20190411141321-3cae06de9d30 h1:PTuC871eMyykb2rns5n21nJvbIQJ7c1HKd0jHd+CgnA=
 github.com/mdlayher/netlink v0.0.0-20190411141321-3cae06de9d30/go.mod h1:t19erlH/I/040715SD0/ktZi33scgSEuOlp57AIFe/c=
+github.com/x-way/iptables-tracer v0.0.0-20190501154639-7d0cedc1af8f h1:CbQ/BC1PsVJEx6DNVHTtR7d6scKUjBUpHVck0EvlNZE=
+github.com/x-way/iptables-tracer v0.0.0-20190501154639-7d0cedc1af8f/go.mod h1:R7kXJQuDstZyu7JmADbAFti/LWBBxzEfTXldYJdCBoU=
+github.com/x-way/iptables-tracer v0.0.0-20190501154939-f449dbcfaee5 h1:P6Ex2MPSLZmkX520ZgHKF6WH0wjeIsK7iTIZB7syqA8=
+github.com/x-way/iptables-tracer v0.0.0-20190501154939-f449dbcfaee5/go.mod h1:R7kXJQuDstZyu7JmADbAFti/LWBBxzEfTXldYJdCBoU=
+github.com/x-way/iptables-tracer v0.0.0-20190501163931-168636dda40a h1:vQ13uFv64EATy/XC4sPyRpvcrjZNrlKb15+YNvz2/dE=
+github.com/x-way/iptables-tracer v0.0.0-20190501163931-168636dda40a/go.mod h1:R7kXJQuDstZyu7JmADbAFti/LWBBxzEfTXldYJdCBoU=
+github.com/x-way/iptables-tracer v0.0.0-20190501165141-f974407f87e1 h1:Smz1/16r0ucB9iOj/gfGgyG7LS6unlwOuOAMuP36xx8=
+github.com/x-way/iptables-tracer v0.0.0-20190501165141-f974407f87e1/go.mod h1:R7kXJQuDstZyu7JmADbAFti/LWBBxzEfTXldYJdCBoU=
+github.com/x-way/iptables-tracer v0.0.0-20190502195204-9a3e3a32171d h1:hf7pMtST63/jNq2SEQ8JGg5axqhwvV/daFOyQa2zDR8=
+github.com/x-way/iptables-tracer v0.0.0-20190502195204-9a3e3a32171d/go.mod h1:R7kXJQuDstZyu7JmADbAFti/LWBBxzEfTXldYJdCBoU=
+github.com/x-way/iptables-tracer v0.0.0-20190502200825-d3aba5b1e83d h1:OuPFYngTIC8ZKfAHAdHqF5svt/I41fYHviPGGjqTM7A=
+github.com/x-way/iptables-tracer v0.0.0-20190502200825-d3aba5b1e83d/go.mod h1:R7kXJQuDstZyu7JmADbAFti/LWBBxzEfTXldYJdCBoU=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3 h1:0GoQqolDA55aaLxZyTzK/Y2ePZzZTUrRacwib7cNsYQ=


### PR DESCRIPTION
Directly use the NFLOG conntrack information when available.
With fallback to the existing information extraction from the packet payload.

Also adds a `-debug` flag to print the ongoing packet handling on STDOUT.